### PR TITLE
Updating to .Net Core 2.1

### DIFF
--- a/src/Shinoa/Shinoa.csproj
+++ b/src/Shinoa/Shinoa.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Shinoa</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Shinoa</PackageId>
@@ -48,10 +48,6 @@
     <PackageReference Include="RestEase" Version="1.4.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
     <PackageReference Include="YamlDotNet" Version="4.2.2-pre0425" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.0" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
The tool "Microsoft.EntityFrameworkCore.Tools.DotNet" is now integrated into .NET Core SDK and thus removed from the project file.